### PR TITLE
Allow Box to be defined using center of box as origin

### DIFF
--- a/examples/cpp.xml
+++ b/examples/cpp.xml
@@ -121,8 +121,8 @@
   -->
   <Box Type="MyBox2" Id="MyBox2" CoordinateSystem="Cartesian" Unit="None">
     <CoordinatesDimensions>
-      <MinX>left</MinX> <!-- or <Left> or <MaxX> or <Right> -->
-      <MinY>bottom</MinY> <!-- or <Bottom> or <MaxY> or <Top> -->
+      <MinX>left</MinX> <!-- or <Left> or <MaxX> or <Right> or <CenterX>-->
+      <MinY>bottom</MinY> <!-- or <Bottom> or <MaxY> or <Top> or <CenterY> -->
       <Width>width</Width>
       <Height>height</Height>
     </CoordinatesDimensions>


### PR DESCRIPTION
Support a box that has it's origin at the centre of the box instead of the top left.

```
  <Box Id="MyBox_Center">
    <CoordinatesDimensions>
      <CenterX>left</CenterX>
      <CenterY>bottom</CenterY>
      <Width>width</Width>
      <Height>height</Height>
    </CoordinatesDimensions>
  </Box>
```

Also, allow mix and match to define one dimention from the center and another from the side.
```
  <Box Id="MyBox_Mixed">
    <CoordinatesDimensions>
      <CenterX>left</CenterX>
      <MinY>bottom</MinY>
      <Width>width</Width>
      <Height>height</Height>
    </CoordinatesDimensions>
  </Box>
```