### PR TITLE
add handling of types decorated with module name

### DIFF
--- a/solution/GraphicalDebugging/Util.cs
+++ b/solution/GraphicalDebugging/Util.cs
@@ -143,6 +143,15 @@ namespace GraphicalDebugging
                     type = type.Remove(i - 1);
                 }
             }
+            if (type.Contains("!"))
+            {
+                //remove bracket-less module declaration sometimes appearing in the variable type (ends with "!" symbol)
+                int i = type.LastIndexOf("!");
+                if (i > 0) // including space
+                {
+                    type = type.Remove(0, i + 1);
+                }
+            }
             if (type.StartsWith("const "))
                 type = type.Remove(0, 6);
             if (type.StartsWith("volatile "))


### PR DESCRIPTION
I run into some types from an external library that were not correctly recognized by the graphical watch. 
In particular, given a type `Foo `in a library `MyLibrary.dll`, in the watch list I have `MyLibrary.dll!Foo`.

A handling for the case  `Foo{MyLibrary.dll!}` was recently added, but also this case appears to be useful.

I tested locally and it works.

I hope that it is fine that I use the `"!"` symbol as last character of module reference, so I remove till such symbol the first
part of the string read