### PR TITLE
Feature: inserting multiple items from clipboard

### DIFF
--- a/solution/GraphicalDebugging/GeometryWatchControl.xaml.cs
+++ b/solution/GraphicalDebugging/GeometryWatchControl.xaml.cs
@@ -162,7 +162,13 @@ namespace GraphicalDebugging
             }
             else if (e.Key == System.Windows.Input.Key.V && e.KeyboardDevice.Modifiers.HasFlag(System.Windows.Input.ModifierKeys.Control))
             {
-                Util.PasteDataGridItemFromClipboard(dataGrid, Geometries);
+                Util.PasteDataGridItemFromClipboard(dataGrid, Geometries, (name) =>
+                {
+                    var newItem = new GeometryItem() { Name = name };
+                    newItem.PropertyChanged += GeometryItem_PropertyChanged;
+                    return newItem;
+                });
+                UpdateItems(false);
             }
         }
 

--- a/solution/GraphicalDebugging/GraphicalWatchControl.xaml.cs
+++ b/solution/GraphicalDebugging/GraphicalWatchControl.xaml.cs
@@ -88,7 +88,13 @@ namespace GraphicalDebugging
             }
             else if (e.Key == System.Windows.Input.Key.V && e.KeyboardDevice.Modifiers.HasFlag(System.Windows.Input.ModifierKeys.Control))
             {
-                Util.PasteDataGridItemFromClipboard(dataGrid, Variables);
+                Util.PasteDataGridItemFromClipboard(dataGrid, Variables, (name) =>
+                {
+                    var newItem = new GraphicalItem() { Name = name };
+                    newItem.PropertyChanged += GraphicalItem_PropertyChanged;
+                    return newItem;
+                });
+                UpdateItems(false);
             }
         }
 

--- a/solution/GraphicalDebugging/PlotWatchControl.xaml.cs
+++ b/solution/GraphicalDebugging/PlotWatchControl.xaml.cs
@@ -8,10 +8,12 @@ namespace GraphicalDebugging
 {
     using System;
     using System.Collections.ObjectModel;
+    using System.ComponentModel;
     using System.Drawing;
     using System.Reflection;
     using System.Windows;
     using System.Windows.Controls;
+    using System.Windows.Media;
     using System.Windows.Media.Imaging;
 
     /// <summary>
@@ -163,7 +165,13 @@ namespace GraphicalDebugging
             }
             else if (e.Key == System.Windows.Input.Key.V && e.KeyboardDevice.Modifiers.HasFlag(System.Windows.Input.ModifierKeys.Control))
             {
-                Util.PasteDataGridItemFromClipboard(dataGrid, Plots);
+                Util.PasteDataGridItemFromClipboard(dataGrid, Plots, (name) =>
+                {
+                    var newItem = new PlotItem() { Name = name };
+                    newItem.PropertyChanged += PlotItem_PropertyChanged;
+                    return newItem;
+                });
+                UpdateItems(false);
             }
         }
 

--- a/solution/GraphicalDebugging/PlotWatchControl.xaml.cs
+++ b/solution/GraphicalDebugging/PlotWatchControl.xaml.cs
@@ -8,12 +8,10 @@ namespace GraphicalDebugging
 {
     using System;
     using System.Collections.ObjectModel;
-    using System.ComponentModel;
     using System.Drawing;
     using System.Reflection;
     using System.Windows;
     using System.Windows.Controls;
-    using System.Windows.Media;
     using System.Windows.Media.Imaging;
 
     /// <summary>


### PR DESCRIPTION
This adds option to insert multiple items separated by new line from clipboard when selecting row and hitting Ctrl+V. It will always insert items above selected row. Old Ctrl+V behaviour is preserved, when clipboard does not contain new line it will replace existing item.

I did not find a way to make "generic" item in PasteDataGridItemFromClipboard method that would work for all 3 cases so I added a callback which requests new item to be created by the caller. Maybe there is a way to improve this code?

Also one extra case could be that text in clipboard contains new line but only single item. In that case I'm not sure what is better, inserting one new item (currently implemented) or replacing the selected item. What do you think?